### PR TITLE
Make Drone Server cancellation requests actually call cancel() to cle…

### DIFF
--- a/runtime/runner.go
+++ b/runtime/runner.go
@@ -117,11 +117,12 @@ func (s *Runner) Run(ctx context.Context, stage *drone.Stage) error {
 	go func() {
 		done, _ := s.Client.Watch(ctxdone, data.Build.ID)
 		if done {
-			cancel()
 			log.Debugln("received cancellation")
 		} else {
 			log.Debugln("done listening for cancellations")
 		}
+		log.Debugln("cancelling pipeline")
+		cancel()
 	}()
 
 	envs := environ.Combine(


### PR DESCRIPTION
…anup the pipeline / containers immediately

This takes care of issues I've seen myself with none of the containers being cleaned up after a cancellation. I've also seen quite a few posts related to this on discourse

When I ran the pipeline - and ran the docker runner in debug I noticed that I'd see the message 

```
drone-agent_1   | time="2019-11-21T10:29:56Z" level=debug msg="done listening for cancellations"
```

This ultimately does not call `cancel()` to cancel all process contexts and ultimately allow the runner logic to bubble back up to the deferred `e.engine.Destroy`

The Goroutine check doesn't appear to be as intended, so I just cancel when the watch for cancellation watch comes back at all

```
drone-agent_1   | time="2019-11-21T10:29:56Z" level=debug msg="done listening for cancellations" build.id=579 build.number=192 repo.id=64 repo.name=blender repo.namespace=- stage.id=573 stage.name="Blender CI Pipeline" stage.number=1 thread=7
drone-agent_1   | time="2019-11-21T10:29:56Z" level=debug msg="cancelling pipeline" build.id=579 build.number=192 repo.id=64 repo.name=blender repo.namespace=- stage.id=573 stage.name="Blender CI Pipeline" stage.number=1 thread=7
``` 

I see my containers cleanup afterwards

```
docker ps | grep runner | wc -l
5
docker ps | grep runner | wc -l
1
```

In my use case its important particularly because builds become blocked by another because each one will lock a DinD instance for caching. So to be able to cancel effectively to save up to 10-15 minutes at a time is important.

You may want to handle this differently and I would understand that as well, either way here is a PR
