### PR TITLE
adds shm_size yaml option to steps and services

### DIFF
--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -101,7 +101,7 @@ type (
 		Pull        string                         `json:"pull,omitempty"`
 		Settings    map[string]*manifest.Parameter `json:"settings,omitempty"`
 		Shell       string                         `json:"shell,omitempty"`
-		ShmSize     manifest.BytesSize             `json:"shm_size,omitempty"`
+		ShmSize     manifest.BytesSize             `json:"shm_size,omitempty" yaml:"shm_size"`
 		User        string                         `json:"user,omitempty"`
 		Volumes     []*VolumeMount                 `json:"volumes,omitempty"`
 		When        manifest.Conditions            `json:"when,omitempty"`


### PR DESCRIPTION
this PR adds missing ability to setup shm_size to steps/services as discussed in (https://discourse.drone.io/t/shm-size-setting-not-respected-in-drone-1-0/4921/2) and  fix the opened issue in https://github.com/drone/drone/issues/2890