### PR TITLE
chmod .netrc to private

### DIFF
--- a/engine/compiler/shell/shell.go
+++ b/engine/compiler/shell/shell.go
@@ -36,6 +36,7 @@ func Script(commands []string) string {
 const optionScript = `
 if [ ! -z "${DRONE_NETRC_FILE}" ]; then
 	echo $DRONE_NETRC_FILE > $HOME/.netrc
+	chmod 600 $HOME/.netrc
 fi
 
 unset DRONE_SCRIPT


### PR DESCRIPTION
netrc gem checks for permissions and drone-runner-docker creates the file with 644 permission

```
Netrc::Error:
       Permission bits for '/root/.netrc' should be 0600, but are 644
```

