### PR TITLE
The error from docker pull is written to the log - otherwise we have …

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -141,6 +141,8 @@ func (e *Docker) Run(ctx context.Context, specv runtime.Spec, stepv runtime.Step
 	// create the container
 	err := e.create(ctx, spec, step, output)
 	if err != nil {
+		// in cases where the image cannot be pulled an empty log will be generated if we do not log the error here ...
+		io.WriteString(output, err.Error())
 		return nil, errors.TrimExtraInfo(err)
 	}
 	// start the container

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -142,7 +142,7 @@ func (e *Docker) Run(ctx context.Context, specv runtime.Spec, stepv runtime.Step
 	err := e.create(ctx, spec, step, output)
 	if err != nil {
 		// in cases where the image cannot be pulled an empty log will be generated if we do not log the error here ...
-		io.WriteString(output, err.Error())
+		io.WriteString(output, errors.TrimExtraInfo(err).Error())
 		return nil, errors.TrimExtraInfo(err)
 	}
 	// start the container


### PR DESCRIPTION
…no clue what's goin on.

We have been missing the auth creds within the secrets and the image could not be pulled.
There was no output and it took a while to find the reason ;-)

With this change the docker error is at least written to the log.

Please let me know if this is the proper way to fix this or if the error shall be taken care of at a higher level ...

THX

![Screenshot from 2020-06-18 10-15-17](https://user-images.githubusercontent.com/1005065/84995964-f092ba00-b14c-11ea-9d63-38e343270d06.png)
