### PR TITLE
check privileged image whitelist in service section

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -274,6 +274,10 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 		if !src.When.Match(match) {
 			dst.RunPolicy = runtime.RunNever
 		}
+
+		if c.isPrivileged(src) {
+			dst.Privileged = true
+		}
 	}
 
 	// create steps


### PR DESCRIPTION
This pull request is a simple copy + paste commit from this  drone-runner-kube commit:
https://github.com/drone-runners/drone-runner-kube/commit/c4bfe0a0d8483a6b59c61ec6517896cb36131ef2

Hopefully it will work in same way in this runner.
The goal is to always run services in privileged mode, if the image/plugin is whitelisted.