### PR TITLE
force logs as json

### DIFF
--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -266,6 +266,7 @@ func setupLogger(config Config) {
 	if config.Trace {
 		logrus.SetLevel(logrus.TraceLevel)
 	}
+	logrus.SetFormatter(&logrus.JSONFormatter{})
 }
 
 // Register the daemon command.

--- a/command/exec.go
+++ b/command/exec.go
@@ -222,6 +222,8 @@ func (c *execCommand) run(*kingpin.ParseContext) error {
 	if c.Trace {
 		logrus.SetLevel(logrus.TraceLevel)
 	}
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+
 	logger.Default = logger.Logrus(
 		logrus.NewEntry(
 			logrus.StandardLogger(),


### PR DESCRIPTION
Drone server is logging JSON by default.
This PR force the drone-runner-docker to log as JSON too.