### PR TITLE
Use ContainerStop for graceful termination

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"time"
 
 	"github.com/drone-runners/drone-runner-docker/internal/docker/errors"
 	"github.com/drone-runners/drone-runner-docker/internal/docker/image"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+        "time"
 
 	"github.com/drone-runners/drone-runner-docker/internal/docker/errors"
 	"github.com/drone-runners/drone-runner-docker/internal/docker/image"
@@ -105,7 +106,7 @@ func (e *Docker) Destroy(ctx context.Context, specv runtime.Spec) error {
 
 	// stop all containers
 	for _, step := range spec.Steps {
-		e.client.ContainerKill(ctx, step.ID, "9")
+		e.client.ContainerStop(ctx, step.ID, time.Seconds(30))
 	}
 
 	// cleanup all containers

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-        "time"
+	"time"
 
 	"github.com/drone-runners/drone-runner-docker/internal/docker/errors"
 	"github.com/drone-runners/drone-runner-docker/internal/docker/image"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -25,6 +25,8 @@ import (
 	"github.com/docker/docker/client"
 )
 
+var terminationGracePeriod = 30 * time.Second
+
 // Opts configures the Docker engine.
 type Opts struct {
 	HidePull bool
@@ -106,7 +108,7 @@ func (e *Docker) Destroy(ctx context.Context, specv runtime.Spec) error {
 
 	// stop all containers
 	for _, step := range spec.Steps {
-		e.client.ContainerStop(ctx, step.ID, 30 * time.Second)
+		e.client.ContainerStop(ctx, step.ID, &terminationGracePeriod)
 	}
 
 	// cleanup all containers

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"time"
 
 	"github.com/drone-runners/drone-runner-docker/internal/docker/errors"
 	"github.com/drone-runners/drone-runner-docker/internal/docker/image"
@@ -106,7 +105,7 @@ func (e *Docker) Destroy(ctx context.Context, specv runtime.Spec) error {
 
 	// stop all containers
 	for _, step := range spec.Steps {
-		e.client.ContainerStop(ctx, step.ID, time.Seconds(30))
+		e.client.ContainerStop(ctx, step.ID, 30 * time.Second)
 	}
 
 	// cleanup all containers


### PR DESCRIPTION
When SIGKILL is sent to the containers, none of the dangling resource manage to clean up.

This is especially true for tools like `packer` and `terraform` where the clean up phase actually involves external cloud resources.