### PR TITLE
fix: use ascii for _netrc file

### DIFF
--- a/engine/compiler/shell/powershell/powershell.go
+++ b/engine/compiler/shell/powershell/powershell.go
@@ -34,6 +34,7 @@ func Script(commands []string) string {
 // optionScript is a helper script this is added to the build
 // to set shell options, in this case, to exit on error.
 const optionScript = `
+$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 if ($Env:DRONE_NETRC_MACHINE) {
 @"
 machine $Env:DRONE_NETRC_MACHINE

--- a/engine/compiler/shell/powershell/powershell.go
+++ b/engine/compiler/shell/powershell/powershell.go
@@ -34,13 +34,12 @@ func Script(commands []string) string {
 // optionScript is a helper script this is added to the build
 // to set shell options, in this case, to exit on error.
 const optionScript = `
-$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 if ($Env:DRONE_NETRC_MACHINE) {
 @"
 machine $Env:DRONE_NETRC_MACHINE
 login $Env:DRONE_NETRC_USERNAME
 password $Env:DRONE_NETRC_PASSWORD
-"@ > (Join-Path $Env:USERPROFILE '_netrc');
+"@ | out-file (Join-Path $Env:USERPROFILE '_netrc') -encoding ascii;
 }
 [Environment]::SetEnvironmentVariable("DRONE_NETRC_USERNAME", $null);
 [Environment]::SetEnvironmentVariable("DRONE_NETRC_PASSWORD", $null);


### PR DESCRIPTION
This change sets the out-file encoding to `ascii` for  writing `_netrc` on windows powershell.

Otherwise it will default to `UTF-8-BOM` which causes git to be not able to read the `_netrc` file.