### PR TITLE
Use correct permission 1777 with sticky bit for /dev/shm

### DIFF
--- a/engine/convert.go
+++ b/engine/convert.go
@@ -227,6 +227,12 @@ func toMount(source *Volume, target *VolumeMount) mount.Mount {
 			SizeBytes: source.EmptyDir.SizeLimit,
 			Mode:      0700,
 		}
+
+		// The directory /dev/shm is always "drwxrwxrwt root root" as it relies
+		// on the sticky bit.
+		if to.Target == "/dev/shm" {
+			to.TmpfsOptions.Mode = 1777;
+		}
 	}
 	return to
 }


### PR DESCRIPTION
Permission on /dev/shm is always "drwxrwxrwt root root"
but this was changed to 0700 when mounting a memory
volume over /dev/shm, loosing the sticky bit and the
ability for an app running as a user to use shm_open.
So this patch adds a special case to give /dev/shm
the correct permissions 1777 that relies on the sticky
bit.

