### PR TITLE
Test that inverse matches work for `DRONE_LIMIT_REPOS`

### DIFF
--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -30,13 +30,21 @@ func TestFunc(t *testing.T) {
 			match:   true,
 			matcher: Func([]string{"spaceghost/*", "octocat/*"}, []string{"push"}, true),
 		},
-		// repoisitory matching
+		// repository matching
 		{
 			repo:    "octocat/hello-world",
 			event:   "pull_request",
 			trusted: false,
 			match:   true,
 			matcher: Func([]string{"spaceghost/*", "octocat/*"}, []string{}, false),
+		},
+		// repository matching, skipping an org
+		{
+			repo:    "octocat/hello-world",
+			event:   "pull_request",
+			trusted: false,
+			match:   true,
+			matcher: Func([]string{"!spaceghost/*", "octocat/*"}, []string{}, false),
 		},
 		// event matching
 		{
@@ -66,6 +74,22 @@ func TestFunc(t *testing.T) {
 			trusted: false,
 			match:   false,
 			matcher: Func([]string{"octocat/*"}, []string{}, false),
+		},
+		// repository matching, skip all repos in the org
+		{
+			repo:    "spaceghost/hello-world",
+			event:   "pull_request",
+			trusted: false,
+			match:   false,
+			matcher: Func([]string{"!spaceghost/*"}, []string{}, false),
+		},
+		// repository matching, skip a concrete repo
+		{
+			repo:    "spaceghost/hello-world",
+			event:   "pull_request",
+			trusted: false,
+			match:   false,
+			matcher: Func([]string{"!spaceghost/hello-world"}, []string{}, false),
 		},
 		// event matching
 		{


### PR DESCRIPTION
Reading the docs for [`DRONE_LIMIT_REPOS`](https://docs.drone.io/runner/docker/configuration/reference/drone-limit-repos/) it was not clear to me that we could add negated expressions.

For context, my use case is the following:
* Having a Docker runner that processes jobs for all repos in my org, except one.
* Having a Docker runner that processes jobs for only a single repo in my org.

Added some additional unit tests to verify that `DRONE_LIMIT_REPOS` works for inverse matches. Given that the matching is based on `path/filepath`, inverse matches are supported.

I will open a PR to update the docs as well.