### PR TITLE
Require secrets to be present

### DIFF
--- a/command/daemon/config.go
+++ b/command/daemon/config.go
@@ -42,19 +42,20 @@ type Config struct {
 	}
 
 	Runner struct {
-		Name        string            `envconfig:"DRONE_RUNNER_NAME"`
-		Capacity    int               `envconfig:"DRONE_RUNNER_CAPACITY" default:"2"`
-		Procs       int64             `envconfig:"DRONE_RUNNER_MAX_PROCS"`
-		Environ     map[string]string `envconfig:"DRONE_RUNNER_ENVIRON"`
-		EnvFile     string            `envconfig:"DRONE_RUNNER_ENV_FILE"`
-		Secrets     map[string]string `envconfig:"DRONE_RUNNER_SECRETS"`
-		Labels      map[string]string `envconfig:"DRONE_RUNNER_LABELS"`
-		Volumes     map[string]string `envconfig:"DRONE_RUNNER_VOLUMES"`
-		Devices     []string          `envconfig:"DRONE_RUNNER_DEVICES"`
-		Networks    []string          `envconfig:"DRONE_RUNNER_NETWORKS"`
-		NetworkOpts map[string]string `envconfig:"DRONE_RUNNER_NETWORK_OPTS"`
-		Privileged  []string          `envconfig:"DRONE_RUNNER_PRIVILEGED_IMAGES"`
-		Clone       string            `envconfig:"DRONE_RUNNER_CLONE_IMAGE"`
+		Name            string            `envconfig:"DRONE_RUNNER_NAME"`
+		Capacity        int               `envconfig:"DRONE_RUNNER_CAPACITY" default:"2"`
+		Procs           int64             `envconfig:"DRONE_RUNNER_MAX_PROCS"`
+		Environ         map[string]string `envconfig:"DRONE_RUNNER_ENVIRON"`
+		EnvFile         string            `envconfig:"DRONE_RUNNER_ENV_FILE"`
+		Secrets         map[string]string `envconfig:"DRONE_RUNNER_SECRETS"`
+		SecretsRequired bool              `envconfig:"DRONE_RUNNER_SECRETS_REQUIRED"`
+		Labels          map[string]string `envconfig:"DRONE_RUNNER_LABELS"`
+		Volumes         map[string]string `envconfig:"DRONE_RUNNER_VOLUMES"`
+		Devices         []string          `envconfig:"DRONE_RUNNER_DEVICES"`
+		Networks        []string          `envconfig:"DRONE_RUNNER_NETWORKS"`
+		NetworkOpts     map[string]string `envconfig:"DRONE_RUNNER_NETWORK_OPTS"`
+		Privileged      []string          `envconfig:"DRONE_RUNNER_PRIVILEGED_IMAGES"`
+		Clone           string            `envconfig:"DRONE_RUNNER_CLONE_IMAGE"`
 	}
 
 	Platform struct {

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -81,8 +81,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 	)
 
 	opts := engine.Opts{
-		HidePull:        !config.Docker.Stream,
-		SecretsRequired: config.Runner.SecretsRequired,
+		HidePull: !config.Docker.Stream,
 	}
 	engine, err := engine.NewEnv(opts)
 	if err != nil {
@@ -178,6 +177,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 					config.Secret.SkipVerify,
 				),
 			),
+			SecretsRequired: config.Runner.SecretsRequired,
 		},
 		Exec: runtime.NewExecer(
 			tracer,

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -81,7 +81,8 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 	)
 
 	opts := engine.Opts{
-		HidePull: !config.Docker.Stream,
+		HidePull:        !config.Docker.Stream,
+		SecretsRequired: config.Runner.SecretsRequired,
 	}
 	engine, err := engine.NewEnv(opts)
 	if err != nil {

--- a/command/daemon/process.go
+++ b/command/daemon/process.go
@@ -53,8 +53,7 @@ func (c *processCommand) run(*kingpin.ParseContext) error {
 	)
 
 	opts := engine.Opts{
-		HidePull:        !config.Docker.Stream,
-		SecretsRequired: config.Runner.SecretsRequired,
+		HidePull: !config.Docker.Stream,
 	}
 	engine, err := engine.NewEnv(opts)
 	if err != nil {
@@ -115,6 +114,7 @@ func (c *processCommand) run(*kingpin.ParseContext) error {
 					config.Secret.SkipVerify,
 				),
 			),
+			SecretsRequired: config.Runner.SecretsRequired,
 		},
 		Exec: runtime.NewExecer(
 			remote,

--- a/command/daemon/process.go
+++ b/command/daemon/process.go
@@ -53,7 +53,8 @@ func (c *processCommand) run(*kingpin.ParseContext) error {
 	)
 
 	opts := engine.Opts{
-		HidePull: !config.Docker.Stream,
+		HidePull:        !config.Docker.Stream,
+		SecretsRequired: config.Runner.SecretsRequired,
 	}
 	engine, err := engine.NewEnv(opts)
 	if err != nil {

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -381,7 +381,6 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 	for _, step := range spec.Steps {
 		for _, s := range step.Secrets {
 			secret, ok := c.findSecret(ctx, args, s.Name)
-			s.Found = ok
 			if ok {
 				s.Data = []byte(secret)
 			}

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -381,6 +381,7 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 	for _, step := range spec.Steps {
 		for _, s := range step.Secrets {
 			secret, ok := c.findSecret(ctx, args, s.Name)
+			s.Found = ok
 			if ok {
 				s.Data = []byte(secret)
 			}

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -111,6 +111,9 @@ type Compiler struct {
 	// into the pipeline step.
 	Secret secret.Provider
 
+	// SecretsRequired will disallow unset secrets if true
+	SecretsRequired bool
+
 	// Registry returns a list of registry credentials that can be
 	// used to pull private container images.
 	Registry registry.Provider
@@ -182,6 +185,10 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 		}
 	}
 
+	secretsRequired := c.SecretsRequired
+	if s := pipeline.SecretsRequired; s != nil {
+		secretsRequired = *s
+	}
 	spec := &engine.Spec{
 		Network: engine.Network{
 			ID:      random(),
@@ -194,7 +201,8 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 			Variant: pipeline.Platform.Variant,
 			Version: pipeline.Platform.Version,
 		},
-		Volumes: []*engine.Volume{volume},
+		Volumes:         []*engine.Volume{volume},
+		SecretsRequired: secretsRequired,
 	}
 
 	// list the global environment variables

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -30,23 +30,20 @@ import (
 
 // Opts configures the Docker engine.
 type Opts struct {
-	HidePull        bool
-	SecretsRequired bool
+	HidePull bool
 }
 
 // Docker implements a Docker pipeline engine.
 type Docker struct {
-	client          client.APIClient
-	hidePull        bool
-	secretsRequired bool
+	client   client.APIClient
+	hidePull bool
 }
 
 // New returns a new engine.
 func New(client client.APIClient, opts Opts) *Docker {
 	return &Docker{
-		client:          client,
-		hidePull:        opts.HidePull,
-		secretsRequired: opts.SecretsRequired,
+		client:   client,
+		hidePull: opts.HidePull,
 	}
 }
 
@@ -236,7 +233,7 @@ func (e *Docker) create(ctx context.Context, spec *Spec, step *Step, output io.W
 	}
 	if len(secretErrors) > 0 {
 		message := "some secrets could not be mounted. Check Drone's (and your external secret provider's) logs for more info. \n" + strings.Join(secretErrors, "\n")
-		if e.secretsRequired {
+		if spec.SecretsRequired {
 			return goerrors.New(message)
 		}
 		logger.FromContext(ctx).Info(message)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -230,7 +230,7 @@ func (e *Docker) create(ctx context.Context, spec *Spec, step *Step, output io.W
 
 	var secretErrors []string
 	for _, secret := range step.Secrets {
-		if !secret.Found {
+		if len(secret.Data) == 0 {
 			secretErrors = append(secretErrors, fmt.Sprintf("Could not find secret `%s` to be mounted on env variable `%s`. ", secret.Name, secret.Env))
 		}
 	}

--- a/engine/resource/parser_test.go
+++ b/engine/resource/parser_test.go
@@ -19,6 +19,7 @@ func TestParse(t *testing.T) {
 		return
 	}
 
+	secretsRequired := true
 	want := []manifest.Resource{
 		&manifest.Signature{
 			Kind: "signature",
@@ -48,7 +49,8 @@ func TestParse(t *testing.T) {
 			Clone: manifest.Clone{
 				Depth: 50,
 			},
-			PullSecrets: []string{"dockerconfigjson"},
+			PullSecrets:     []string{"dockerconfigjson"},
+			SecretsRequired: &secretsRequired,
 			Trigger: manifest.Conditions{
 				Branch: manifest.Condition{
 					Include: []string{"master"},

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -34,12 +34,13 @@ type Pipeline struct {
 	Platform    manifest.Platform    `json:"platform,omitempty"`
 	Trigger     manifest.Conditions  `json:"conditions,omitempty"`
 
-	Environment map[string]string `json:"environment,omitempty"`
-	Services    []*Step           `json:"services,omitempty"`
-	Steps       []*Step           `json:"steps,omitempty"`
-	Volumes     []*Volume         `json:"volumes,omitempty"`
-	PullSecrets []string          `json:"image_pull_secrets,omitempty" yaml:"image_pull_secrets"`
-	Workspace   Workspace         `json:"workspace,omitempty"`
+	Environment     map[string]string `json:"environment,omitempty"`
+	Services        []*Step           `json:"services,omitempty"`
+	Steps           []*Step           `json:"steps,omitempty"`
+	Volumes         []*Volume         `json:"volumes,omitempty"`
+	PullSecrets     []string          `json:"image_pull_secrets,omitempty" yaml:"image_pull_secrets"`
+	Workspace       Workspace         `json:"workspace,omitempty"`
+	SecretsRequired *bool             `json:"disallow_unset_secrets,omitempty"`
 }
 
 // GetVersion returns the resource version.

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -40,7 +40,7 @@ type Pipeline struct {
 	Volumes         []*Volume         `json:"volumes,omitempty"`
 	PullSecrets     []string          `json:"image_pull_secrets,omitempty" yaml:"image_pull_secrets"`
 	Workspace       Workspace         `json:"workspace,omitempty"`
-	SecretsRequired *bool             `json:"disallow_unset_secrets,omitempty"`
+	SecretsRequired *bool             `json:"disallow_unset_secrets,omitempty" yaml:"disallow_unset_secrets"`
 }
 
 // GetVersion returns the resource version.

--- a/engine/resource/testdata/manifest.yml
+++ b/engine/resource/testdata/manifest.yml
@@ -14,6 +14,8 @@ type: docker
 name: default
 version: 1
 
+disallow_unset_secrets: true
+
 platform:
   os: linux
   arch: arm64

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -61,11 +61,10 @@ type (
 
 	// Secret represents a secret variable.
 	Secret struct {
-		Name  string `json:"name,omitempty"`
-		Env   string `json:"env,omitempty"`
-		Data  []byte `json:"data,omitempty"`
-		Mask  bool   `json:"mask,omitempty"`
-		Found bool
+		Name string `json:"name,omitempty"`
+		Env  string `json:"env,omitempty"`
+		Data []byte `json:"data,omitempty"`
+		Mask bool   `json:"mask,omitempty"`
 	}
 
 	// Platform defines the target platform.

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -61,10 +61,11 @@ type (
 
 	// Secret represents a secret variable.
 	Secret struct {
-		Name string `json:"name,omitempty"`
-		Env  string `json:"env,omitempty"`
-		Data []byte `json:"data,omitempty"`
-		Mask bool   `json:"mask,omitempty"`
+		Name  string `json:"name,omitempty"`
+		Env   string `json:"env,omitempty"`
+		Data  []byte `json:"data,omitempty"`
+		Mask  bool   `json:"mask,omitempty"`
+		Found bool
 	}
 
 	// Platform defines the target platform.

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -15,11 +15,12 @@ type (
 	// required instructions for reproducible pipeline
 	// execution.
 	Spec struct {
-		Platform Platform  `json:"platform,omitempty"`
-		Steps    []*Step   `json:"steps,omitempty"`
-		Internal []*Step   `json:"internal,omitempty"`
-		Volumes  []*Volume `json:"volumes,omitempty"`
-		Network  Network   `json:"network"`
+		Platform        Platform  `json:"platform,omitempty"`
+		Steps           []*Step   `json:"steps,omitempty"`
+		Internal        []*Step   `json:"internal,omitempty"`
+		Volumes         []*Volume `json:"volumes,omitempty"`
+		Network         Network   `json:"network"`
+		SecretsRequired bool      `json:"disallow_unset_secrets"`
 	}
 
 	// Step defines a pipeline step.


### PR DESCRIPTION
Adds a `DRONE_RUNNER_SECRETS_REQUIRED` env variable that instructs Drone to crash if secrets are not found on their provider
If this env variable is not set, current behavior remains which is to create the env variable with an empty value, making the feedback to the user much less clear

![image](https://user-images.githubusercontent.com/29210090/116611141-06901000-a904-11eb-96fd-1ec4c5e6194e.png)


