### PR TITLE
Removed empty environment variable constraint

### DIFF
--- a/engine/convert.go
+++ b/engine/convert.go
@@ -252,9 +252,7 @@ func toVolumeType(from *Volume) mount.Type {
 func toEnv(env map[string]string) []string {
 	var envs []string
 	for k, v := range env {
-		if v != "" {
-			envs = append(envs, k+"="+v)
-		}
+		envs = append(envs, k+"="+v)
 	}
 	return envs
 }


### PR DESCRIPTION
What is the reasoning behind this check? I found out about this, because me and my colleague were debugging a pipeline for hours to find out, that one of my environment variables was actually missing. The value of the variable was `""`, an empty string literal, which is a valid value for environment variables. From the input of this function it looks to me like a string type check is not needed as a replacement. 

 @Alexander-Zierhut

