### PR TITLE
Use correct name for the root depends_on yaml key.

### DIFF
--- a/engine/resource/parser_test.go
+++ b/engine/resource/parser_test.go
@@ -48,6 +48,7 @@ func TestParse(t *testing.T) {
 			Clone: manifest.Clone{
 				Depth: 50,
 			},
+			Deps: []string{"dependency"},
 			PullSecrets: []string{"dockerconfigjson"},
 			Trigger: manifest.Conditions{
 				Branch: manifest.Condition{

--- a/engine/resource/pipeline.go
+++ b/engine/resource/pipeline.go
@@ -26,7 +26,7 @@ type Pipeline struct {
 	Kind    string   `json:"kind,omitempty"`
 	Type    string   `json:"type,omitempty"`
 	Name    string   `json:"name,omitempty"`
-	Deps    []string `json:"depends_on,omitempty"`
+	Deps    []string `json:"depends_on,omitempty" yaml:"depends_on"`
 
 	Clone       manifest.Clone       `json:"clone,omitempty"`
 	Concurrency manifest.Concurrency `json:"concurrency,omitempty"`

--- a/engine/resource/testdata/manifest.yml
+++ b/engine/resource/testdata/manifest.yml
@@ -14,6 +14,9 @@ type: docker
 name: default
 version: 1
 
+depends_on:
+- dependency
+
 platform:
   os: linux
   arch: arm64


### PR DESCRIPTION
### Our usage of this library

We have a self-developed conversion extension, this extension uses the original YAML format documented at https://readme.drone.io/pipeline/docker/syntax, but adds a few steps to the pipeline.

We use this repository as a golang module and use the following struct to parse the YAML.
https://github.com/drone-runners/drone-runner-docker/blob/master/engine/resource/pipeline.go#L24


### Problem

Multiple pipelines and graph execution do not work since the YAML key `depends_on` does not exist on the struct. 

[drone/drone is using the definition](https://github.com/drone/drone/blob/master/trigger/trigger.go#L399) in [drone/drone-yaml](https://github.com/drone/drone-yaml/blob/master/yaml/pipeline.go#L27). This definition looks correct for `depends_on` but the repository is archived. 