### PR TITLE
Add option to exec to set maximum procs (concurrent steps)

### DIFF
--- a/command/exec.go
+++ b/command/exec.go
@@ -369,6 +369,9 @@ func registerExec(app *kingpin.Application) {
 			),
 		).BoolVar(&c.Pretty)
 
+	cmd.Flag("max-procs", "limits the number of concurrent steps the runner can execute simultaneously").
+		Int64Var(&c.Procs)
+
 	// shared pipeline flags
 	c.Flags = internal.ParseFlags(cmd)
 }


### PR DESCRIPTION
The `exec` command doesn't respect environment variable `DRONE_RUNNER_MAX_RPOCS`. I think it would be better. However, I implemented this single flag for the configuration parameter, which was the only one without a command line argument.