### PR TITLE
add windows server 2022 docker images

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -9,6 +9,7 @@ def main(ctx):
         pipeline_linux(),
         pipeline_windows("1903"),
         pipeline_windows("1809"),
+        pipeline_windows("2022"),
         pipeline_manifest(),
         # manifest
     ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -248,6 +248,55 @@ trigger:
 
 ---
 kind: pipeline
+type: ssh
+name: windows-2022
+
+platform:
+  os: windows
+
+server:
+  host:
+    from_secret: windows_server_2022
+  password:
+    from_secret: windows_password
+  user:
+    from_secret: windows_username
+
+steps:
+- name: build_latest
+  environment:
+    VERSION: 2022
+    USERNAME:
+      from_secret: docker_username
+    PASSWORD:
+      from_secret: docker_password
+  commands:
+  - powershell.exe scripts/windows/latest.ps1
+  when:
+    event: [ push ]
+
+- name: build_tag
+  environment:
+    VERSION: 2022
+    USERNAME:
+      from_secret: docker_username
+    PASSWORD:
+      from_secret: docker_password
+  commands:
+  - powershell.exe scripts/windows/tag.ps1
+  when:
+    event: [ tag ]
+
+depends_on:
+- linux
+
+trigger:
+  ref:
+  - refs/heads/master
+  - refs/tags/*
+
+---
+kind: pipeline
 type: docker
 name: manifest
 
@@ -267,6 +316,7 @@ depends_on:
 - windows-1903
 - windows-1809
 - windows-1909
+- windows-2022
 
 trigger:
   ref:

--- a/docker/Dockerfile.windows.amd64.2022
+++ b/docker/Dockerfile.windows.amd64.2022
@@ -1,0 +1,12 @@
+# escape=`
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+USER ContainerAdministrator
+
+EXPOSE 3000
+ENV GODEBUG netdns=go
+ENV DRONE_PLATFORM_OS windows
+ENV DRONE_PLATFORM_ARCH amd64
+ENV DRONE_PLATFORM_KERNEL 2022
+
+ADD release/windows/amd64/drone-runner-docker.exe C:/drone-runner-docker.exe
+ENTRYPOINT [ "C:\\drone-runner-docker.exe" ]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -58,3 +58,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 1909
+  -
+    image: drone/drone-runner-docker:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-2022-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022


### PR DESCRIPTION
This PR will add the new windows server 2022 docker images

It will need a new worker based on server 2022. Nothing special works the same as on server 2019.