### PR TITLE
use pwsh as entrypoint for step scripts instead of powershell

### DIFF
--- a/engine/compiler/script.go
+++ b/engine/compiler/script.go
@@ -27,7 +27,7 @@ func setupScript(src *resource.Step, dst *engine.Step, os string) {
 // helper function configures the pipeline script for the
 // windows operating system.
 func setupScriptWindows(src *resource.Step, dst *engine.Step) {
-	dst.Entrypoint = []string{"powershell", "-noprofile", "-noninteractive", "-command"}
+	dst.Entrypoint = []string{"pwsh", "-noprofile", "-noninteractive", "-command"}
 	dst.Command = []string{"echo $Env:DRONE_SCRIPT | iex"}
 	dst.Envs["DRONE_SCRIPT"] = powershell.Script(src.Commands)
 	dst.Envs["SHELL"] = "powershell.exe"


### PR DESCRIPTION
The current implementation looks for an entrypoint named `powershell`, which exists in images like `mcr.microsoft.com/powershell:windowsservercore-ltsc2022`, but not in `mcr.microsoft.com/powershell:nanoserver-ltsc2022`, where the cross-platform variant `pwsh` is used. Because of this, only images based on windowsservercore can be used.

The windowsservercore-based image is 5.37GB, while the nanoserver-based image is 553MB, saving a significant amount of space.

The windowsservercore-based images also offer the `pwsh` command, so by using `pwsh` as entrypoint instead of `powershell`, both nanoserver-based and windowsservercore-based images can be used.