### PR TITLE
override shell used for step scripts

### DIFF
--- a/engine/compiler/script.go
+++ b/engine/compiler/script.go
@@ -27,7 +27,11 @@ func setupScript(src *resource.Step, dst *engine.Step, os string) {
 // helper function configures the pipeline script for the
 // windows operating system.
 func setupScriptWindows(src *resource.Step, dst *engine.Step) {
-	dst.Entrypoint = []string{"powershell", "-noprofile", "-noninteractive", "-command"}
+	sh := "powershell"
+	if len(src.Shell) != 0 {
+		sh = src.Shell
+	}
+	dst.Entrypoint = []string{sh, "-noprofile", "-noninteractive", "-command"}
 	dst.Command = []string{"echo $Env:DRONE_SCRIPT | iex"}
 	dst.Envs["DRONE_SCRIPT"] = powershell.Script(src.Commands)
 	dst.Envs["SHELL"] = "powershell.exe"
@@ -36,7 +40,11 @@ func setupScriptWindows(src *resource.Step, dst *engine.Step) {
 // helper function configures the pipeline script for the
 // linux operating system.
 func setupScriptPosix(src *resource.Step, dst *engine.Step) {
-	dst.Entrypoint = []string{"/bin/sh", "-c"}
+	sh := "/bin/sh"
+	if len(src.Shell) != 0 {
+		sh = src.Shell
+	}
+	dst.Entrypoint = []string{sh, "-c"}
 	dst.Command = []string{`echo "$DRONE_SCRIPT" | /bin/sh`}
 	dst.Envs["DRONE_SCRIPT"] = shell.Script(src.Commands)
 }


### PR DESCRIPTION
This change enables overriding the shell that is used to execute the commands in a step. The motivation for this is that the various Windows images provided by Microsoft do not offer a consistent shell. Some provide `powershell`, while others provide `pwsh`, currently making the latter unusable in pipeline steps. See #34 for more details.

After realizing that the proposed changes in #34 were not sufficient, I took a better look at the code. It turns out the drone configuration file format already provides a key `shell`, available as `resource.Step.Shell` but not used by `drone-runner-docker`. The proposed change does not change the behavior of a step unless it contains a key `shell`. If it does, this shell is used instead of the default `/bin/sh` and `powershell`, respectively.

```yml
steps:
- name: test
  image: alpine:3
  shell: /bin/ash
  commands:
  - echo test
```
```yml
steps:
- name: test
  image: mcr.microsoft.com/powershell:nanoserver-ltsc2022
  shell: pwsh
  commands:
  - echo test
```

I have tried it on Linux and will try it on Windows tomorrow.