### PR TITLE
Add step labels to containers

### DIFF
--- a/engine/compiler/testdata/steps.yml
+++ b/engine/compiler/testdata/steps.yml
@@ -1,0 +1,16 @@
+kind: pipeline
+type: docker
+name: default
+
+clone:
+  disable: true
+
+steps:
+- name: build
+  image: golang
+  commands:
+  - go build
+- name: test
+  image: golang
+  commands:
+  - go test


### PR DESCRIPTION
This adds the following labels:
- `io.drone.step.number`
- `io.drone.step.name`

Use case: We use these as labels when we send our logs to Loki

