### PR TITLE
Add Windows Server 2022 images

### DIFF
--- a/docker/Dockerfile.windows.amd64.21H2
+++ b/docker/Dockerfile.windows.amd64.21H2
@@ -1,0 +1,11 @@
+# escape=`
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+EXPOSE 3000
+ENV GODEBUG=netdns=go
+ENV DRONE_PLATFORM_OS windows
+ENV DRONE_PLATFORM_ARCH amd64
+ENV DRONE_PLATFORM_KERNEL 21H2
+
+ADD release/windows/amd64/drone-runner-docker.exe C:/drone-runner-docker.exe
+ENTRYPOINT [ "C:\\drone-runner-docker.exe" ]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -58,3 +58,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 1909
+  -
+    image: drone/drone-runner-docker:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-21H2-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: 21H2


### PR DESCRIPTION
Adds a Windows Server 2022 compatible image of drone-runner-docker. Tagged as `21H2` as this is what winver reports on the instance.

CI is not added since no CI for this version of Windows is available yet.