### PR TITLE
Add an option to set the NanoCPUS of a container

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -174,6 +174,9 @@ func registerCompile(app *kingpin.Application) {
 	cmd.Flag("privileged", "privileged docker images").
 		StringsVar(&c.Privileged)
 
+	cmd.Flag("nanocpus", "container cpus").
+		Int64Var(&c.Resources.NanoCPUS)
+
 	cmd.Flag("cpu-period", "container cpu period").
 		Int64Var(&c.Resources.CPUPeriod)
 

--- a/command/daemon/config.go
+++ b/command/daemon/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	Resources struct {
 		Memory     int64    `envconfig:"DRONE_MEMORY_LIMIT"`
 		MemorySwap int64    `envconfig:"DRONE_MEMORY_SWAP_LIMIT"`
+		NanoCPUS   int64    `envconfig:"DRONE_NANOCPUS"`
 		CPUQuota   int64    `envconfig:"DRONE_CPU_QUOTA"`
 		CPUPeriod  int64    `envconfig:"DRONE_CPU_PERIOD"`
 		CPUShares  int64    `envconfig:"DRONE_CPU_SHARES"`

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -137,6 +137,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 			Resources: compiler.Resources{
 				Memory:     config.Resources.Memory,
 				MemorySwap: config.Resources.MemorySwap,
+				NanoCPUS:   config.Resources.NanoCPUS,
 				CPUQuota:   config.Resources.CPUQuota,
 				CPUPeriod:  config.Resources.CPUPeriod,
 				CPUShares:  config.Resources.CPUShares,

--- a/command/daemon/process.go
+++ b/command/daemon/process.go
@@ -82,6 +82,7 @@ func (c *processCommand) run(*kingpin.ParseContext) error {
 			Resources: compiler.Resources{
 				Memory:     config.Resources.Memory,
 				MemorySwap: config.Resources.MemorySwap,
+				NanoCPUS:   config.Resources.NanoCPUS,
 				CPUQuota:   config.Resources.CPUQuota,
 				CPUPeriod:  config.Resources.CPUPeriod,
 				CPUShares:  config.Resources.CPUShares,

--- a/command/exec.go
+++ b/command/exec.go
@@ -304,6 +304,9 @@ func registerExec(app *kingpin.Application) {
 	cmd.Flag("privileged", "privileged docker images").
 		StringsVar(&c.Privileged)
 
+	cmd.Flag("nanocpus", "container cpus").
+		Int64Var(&c.Resources.NanoCPUS)
+
 	cmd.Flag("cpu-period", "container cpu period").
 		Int64Var(&c.Resources.CPUPeriod)
 

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -48,6 +48,7 @@ var Privileged = []string{
 type Resources struct {
 	Memory     int64
 	MemorySwap int64
+	NanoCPUS   int64
 	CPUQuota   int64
 	CPUPeriod  int64
 	CPUShares  int64
@@ -461,6 +462,7 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 		if step.ShmSize == 0 {
 			step.ShmSize = c.Resources.ShmSize
 		}
+		step.NanoCPUS = c.Resources.NanoCPUS
 		step.CPUPeriod = c.Resources.CPUPeriod
 		step.CPUQuota = c.Resources.CPUQuota
 		step.CPUShares = c.Resources.CPUShares

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -75,6 +75,7 @@ func toHostConfig(spec *Spec, step *Step) *container.HostConfig {
 	}
 	if isUnlimited(step) == false {
 		config.Resources = container.Resources{
+			NanoCPUs:   step.NanoCPUS,
 			CPUPeriod:  step.CPUPeriod,
 			CPUQuota:   step.CPUQuota,
 			CpusetCpus: strings.Join(step.CPUSet, ","),
@@ -262,6 +263,7 @@ func toEnv(env map[string]string) []string {
 // returns true if the container has no resource limits.
 func isUnlimited(res *Step) bool {
 	return len(res.CPUSet) == 0 &&
+		res.NanoCPUS == 0 &&
 		res.CPUPeriod == 0 &&
 		res.CPUQuota == 0 &&
 		res.CPUShares == 0 &&

--- a/engine/spec.go
+++ b/engine/spec.go
@@ -27,6 +27,7 @@ type (
 		ID           string            `json:"id,omitempty"`
 		Auth         *Auth             `json:"auth,omitempty"`
 		Command      []string          `json:"args,omitempty"`
+		NanoCPUS     int64             `json:"nanocpus,omitempty"`
 		CPUPeriod    int64             `json:"cpu_period,omitempty"`
 		CPUQuota     int64             `json:"cpu_quota,omitempty"`
 		CPUShares    int64             `json:"cpu_shares,omitempty"`


### PR DESCRIPTION
Currently Drone Docker Runner does not support setting the number of CPU cores on Windows. The default number of CPU cores for Hyper-V containers is 2. This limitation has negative impact on parallel builds on Windows.

The pull request adds a "DRONE_NANOCPUS" environment option to manually set the number of cores for containers.

Also see:
[1] https://community.harness.io/t/drone-runner-docker-does-not-use-more-than-2-cores-on-windows/11740
[2] https://github.com/docker/for-win/issues/1877
[3] NanoCPUS: https://pkg.go.dev/github.com/docker/docker/api/types/container#Resources