### PR TITLE
Dockerfile: Add target architecture to Docker images

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -6,7 +6,7 @@ RUN tar -xf tmate-2.4.0-static-linux-amd64.tar.xz
 RUN mv tmate-2.4.0-static-linux-amd64/tmate /bin/
 RUN chmod +x /bin/tmate
 
-FROM alpine:3
+FROM --platform=linux/amd64 alpine:3
 EXPOSE 3000
 
 ENV GODEBUG netdns=go

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -6,7 +6,7 @@ RUN tar -xf tmate-2.4.0-static-linux-arm32v7.tar.xz
 RUN mv tmate-2.4.0-static-linux-arm32v7/tmate /bin/
 RUN chmod +x /bin/tmate
 
-FROM scratch
+FROM --platform=linux/arm scratch
 EXPOSE 3000
 
 ENV GODEBUG netdns=go

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -6,7 +6,7 @@ RUN tar -xf tmate-2.4.0-static-linux-arm64v8.tar.xz
 RUN mv tmate-2.4.0-static-linux-arm64v8/tmate /bin/
 RUN chmod +x /bin/tmate
 
-FROM scratch
+FROM --platform=linux/arm64 scratch
 EXPOSE 3000
 
 ENV GODEBUG netdns=go

--- a/docker/Dockerfile.linux.ppc64le
+++ b/docker/Dockerfile.linux.ppc64le
@@ -6,7 +6,7 @@ RUN tar -xf tmate-2.4.0-static-linux-ppc64le.tar.xz
 RUN mv tmate-2.4.0-static-linux-ppc64le/tmate /bin/
 RUN chmod +x /bin/tmate
 
-FROM scratch
+FROM --platform=linux/ppc64le scratch
 EXPOSE 3000
 
 ENV GODEBUG netdns=go


### PR DESCRIPTION
This should allow the images to show the correct architecture when browsing Docker Hub.

The below page shows the 1.8.2-linux-arm64 image as being OS/ARCH=linux/amd64.

https://hub.docker.com/layers/drone/drone-runner-docker/1.8.2-linux-arm64/images/sha256-c3812c2fce625efb85dc6c8b04e1d15c208185bd336e58007082d0c3571a066a?context=explore

References:
 - https://docs.docker.com/build/building/multi-platform/
 - https://stackoverflow.com/questions/47809904/how-to-set-architecture-for-docker-build-to-arm64