### PR TITLE
[Do NOT merge AS-IS] Windows CMD.exe based runner sample impl

### DIFF
--- a/engine/compiler/script.go
+++ b/engine/compiler/script.go
@@ -26,7 +26,34 @@ func setupScript(src *resource.Step, dst *engine.Step, os string) {
 
 // helper function configures the pipeline script for the
 // windows operating system.
-func setupScriptWindows(src *resource.Step, dst *engine.Step) {
+// WIP, BROKEN
+func setupScriptWindowsCmd(src *resource.Step, dst *engine.Step) {
+
+	//dst.Command = []string{
+	//	"setlocal",
+	//	"EnableDelayedExpansion", "&",
+	//	"for", "/f", "%L", "in", `(%DRONE_SCRIPT%)`,
+	//	"do", "(",
+	//	"echo", "+", "%L",
+	//	")", "&",
+	//}
+
+	//dst.Command = []string{"set/p", "_discard=%DRONE_SCRIPT%<nul>build_script.cmd"} // & call build_script.cmd
+	//dst.Command = []string{`set/p_discard=%DRONE_SCRIPT%<nul>build_script.cmd & dir & echo ================== & type build_script.cmd & echo ================== `} // & call build_script.cmd
+	//dst.Command = []string{"<nul", "(set/p_discard=%DRONE_SCRIPT%)>build_script.cmd"}
+
+	//dst.Command = []string{"set"}
+	//dst.Entrypoint = []string{"cmd", "/S", "/c", "<nul", "(set/p_discard=%DRONE_SCRIPT%)"}
+	//dst.Entrypoint = []string{"cmd", "/S", "/c", "<nul", "(set/p_discard=%DRONE_SCRIPT%)>%DRONE_WORKSPACE%\\§§build§§.cmd"}
+	//dst.Entrypoint = []string{"cmd", "/S", "/c", "echo", "%DRONE_WORKSPACE%\\§§build§§.cmd"}
+	//dst.Entrypoint = []string{"cmd", "/S", "/c"}
+	//dst.Command = []string{"<nul", "set", "/p", "_discard=%DRONE_SCRIPT%>%DRONE_WORKSPACE%__build__.cmd"}
+	//dst.Command = []string{"<nul", "(set", "/p", "_discard=%DRONE_SCRIPT%)"}
+	//dst.Command = []string{}
+	dst.Envs["DRONE_SCRIPT"] = wincmd.Script(src.Commands)
+	dst.Envs["SHELL"] = "cmd.exe"
+}
+
 	dst.Entrypoint = []string{"powershell", "-noprofile", "-noninteractive", "-command"}
 	dst.Command = []string{"echo $Env:DRONE_SCRIPT | iex"}
 	dst.Envs["DRONE_SCRIPT"] = powershell.Script(src.Commands)

--- a/engine/compiler/shell/powershell/powershell.go
+++ b/engine/compiler/shell/powershell/powershell.go
@@ -39,7 +39,7 @@ if ($Env:DRONE_NETRC_MACHINE) {
 machine $Env:DRONE_NETRC_MACHINE
 login $Env:DRONE_NETRC_USERNAME
 password $Env:DRONE_NETRC_PASSWORD
-"@ > (Join-Path $Env:USERPROFILE '_netrc');
+"@ > (Join-Path $Env:USERPROFILE '.netrc');
 }
 [Environment]::SetEnvironmentVariable("DRONE_NETRC_USERNAME", $null);
 [Environment]::SetEnvironmentVariable("DRONE_NETRC_PASSWORD", $null);

--- a/engine/compiler/shell/wincmd/wincmd.go
+++ b/engine/compiler/shell/wincmd/wincmd.go
@@ -1,0 +1,48 @@
+// Package wincmd provides functions for converting shell
+// commands to cmd scripts.
+package wincmd
+
+import (
+	"bytes"
+)
+
+// Script converts a slice of individual shell commands to
+// a cmd script.
+func Script(commands []string) string {
+	buf := new(bytes.Buffer)
+
+	// ignore first linebreak
+	buf.WriteString(optionScript)
+
+	for _, command := range commands {
+		buf.WriteString("echo +--------------------------------\n")
+		buf.WriteString("echo + " + command + "\n")
+		buf.WriteString(command)
+		buf.WriteString(`
+set LastErrorLevel=%ErrorLevel%
+if %LastErrorLevel% gtr 0 (
+  echo ERROR: %LastErrorLevel% 
+  exit /b %LastErrorLevel%
+)` + "\n")
+		buf.WriteString("echo.\n")
+	}
+
+	return buf.String()
+}
+
+// optionScript is a helper script this is added to the build
+// to set shell options, in this case, to exit on error.
+const optionScript = `
+@echo off
+if .%DRONE_NETRC_MACHINE%. neq .. (
+  type nul > %USERPROFILE%\.netrc
+  echo machine %DRONE_NETRC_MACHINE% >> %USERPROFILE%\.netrc
+  echo login %DRONE_NETRC_USERNAME% >> %USERPROFILE%\.netrc
+  echo password %DRONE_NETRC_PASSWORD% >> %USERPROFILE%\.netrc
+)
+set DRONE_NETRC_USERNAME=
+set DRONE_NETRC_PASSWORD=
+set DRONE_NETRC_FILE=
+set DRONE_SCRIPT=
+
+`

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,6 +5,9 @@
 package engine
 
 import (
+	"archive/tar"
+	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"io/ioutil"
@@ -18,6 +21,7 @@ import (
 	"github.com/drone/runner-go/logger"
 	"github.com/drone/runner-go/pipeline/runtime"
 	"github.com/drone/runner-go/registry/auths"
+	"github.com/sirupsen/logrus"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -197,6 +201,32 @@ func (e *Docker) Run(ctx context.Context, specv runtime.Spec, stepv runtime.Step
 	err := e.create(ctx, spec, step, output)
 	if err != nil {
 		return nil, errors.TrimExtraInfo(err)
+	}
+
+	// Copy init script to container only on windows
+	if spec.Platform.OS == "windows" && step.Envs["SHELL"] == "cmd.exe" {
+		if step.Name != "clone" {
+			fileContent := []byte(step.Envs["DRONE_SCRIPT"])
+
+			hdr := &tar.Header{
+				Name: "/drone/drone-build-script.cmd",
+				Size: int64(len(fileContent)),
+			}
+
+			tarBuf := new(bytes.Buffer)
+			tw := tar.NewWriter(tarBuf)
+
+			tw.WriteHeader(hdr)
+			io.Copy(tw, bytes.NewReader(fileContent))
+			tw.Close()
+
+			err = e.client.CopyToContainer(ctx, step.ID, "/", bufio.NewReader(tarBuf), types.CopyToContainerOptions{})
+			if err != nil {
+				logrus.Debugln(hdr.Name + ": " + err.Error())
+			} else {
+				logrus.Debugln("Copied build script: " + hdr.Name)
+			}
+		}
 	}
 	// start the container
 	err = e.start(ctx, step.ID)


### PR DESCRIPTION
I needed to run things off of images that don't  have powershell in them and are unable to easily eval the DRONE_SCRIPT as docker  ENTRYPOINT. I added wincmd shell impl and extended engine.go to inject DRONE_SCRIPT into the created container as `/drone/drone-build-script.cmd`. 

Disclaimer: it works for me, modify for your needs