### PR TITLE
add ExtraHosts in compiler to be attached to step containers

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -90,6 +90,10 @@ type Compiler struct {
 	// are used when creating the docker network.
 	NetworkOpts map[string]string
 
+	// ExtraHosts provides a set of hostname mappings that
+	// should be setup for each pipeline container.
+	ExtraHosts []string
+
 	// NetrcCloneOnly instructs the compiler to only inject
 	// the netrc file into the clone step.
 	NetrcCloneOnly bool
@@ -278,6 +282,7 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 		step := createClone(pipeline)
 		step.ID = random()
 		step.Envs = environ.Combine(envs, step.Envs)
+		step.ExtraHosts = append(step.ExtraHosts, c.ExtraHosts...)
 		step.WorkingDir = full
 		step.Labels = stageLabels
 		step.Pull = engine.PullIfNotExists
@@ -309,6 +314,7 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 		dst.Detach = true
 		dst.Envs = environ.Combine(envs, dst.Envs)
 		dst.Volumes = append(dst.Volumes, mount)
+		dst.ExtraHosts = append(dst.ExtraHosts, c.ExtraHosts...)
 		dst.Labels = stageLabels
 		setupScript(src, dst, os)
 		setupWorkdir(src, dst, full)
@@ -329,6 +335,7 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 	for _, src := range pipeline.Steps {
 		dst := createStep(pipeline, src)
 		dst.Envs = environ.Combine(envs, dst.Envs)
+		dst.ExtraHosts = append(dst.ExtraHosts, c.ExtraHosts...)
 		dst.Volumes = append(dst.Volumes, mount)
 		dst.Labels = stageLabels
 		setupScript(src, dst, os)

--- a/engine2/compiler/compiler_impl.go
+++ b/engine2/compiler/compiler_impl.go
@@ -86,6 +86,10 @@ type CompilerImpl struct {
 	// mounted to each pipeline container.
 	Volumes map[string]string
 
+	// ExtraHosts provides a set of hostname mappings that
+	// should be setup for each pipeline container.
+	ExtraHosts []string
+
 	// Clone overrides the default plugin image used
 	// when cloning a repository.
 	Clone string
@@ -287,6 +291,7 @@ func (c *CompilerImpl) Compile(ctx context.Context, args Args) (*engine.Spec, er
 		step := createClone(platform_, clone_)
 		step.ID = random()
 		step.Envs = environ.Combine(envs, step.Envs)
+		step.ExtraHosts = append(step.ExtraHosts, c.ExtraHosts...)
 		step.WorkingDir = "/gitness"
 		step.Labels = stageLabels
 		step.Pull = engine.PullIfNotExists
@@ -348,6 +353,7 @@ func (c *CompilerImpl) Compile(ctx context.Context, args Args) (*engine.Spec, er
 				step_.Envs = environ.Combine(envs, step_.Envs)
 				step_.Volumes = append(step_.Volumes, mount)
 				step_.Labels = stageLabels
+				step_.ExtraHosts = append(step_.ExtraHosts, c.ExtraHosts...)
 
 				if src.When != nil {
 					if when := src.When.Eval; when != "" {


### PR DESCRIPTION
This is primarily for supporting the use case of Linux and host.docker.internal. For linux, we need to provide --add-host specification for host.docker.internal to take effect. In Mac/windows this is not needed