### PR TITLE
Adding more details to a couple of step name related errors

### DIFF
--- a/engine/linter/linter.go
+++ b/engine/linter/linter.go
@@ -15,10 +15,6 @@ import (
 	"github.com/drone/runner-go/manifest"
 )
 
-// ErrDuplicateStepName is returned when two Pipeline steps
-// have the same name.
-var ErrDuplicateStepName = errors.New("linter: duplicate step names")
-
 // Opts provides linting options.
 type Opts struct {
 	Trusted bool
@@ -53,22 +49,6 @@ func checkPipeline(pipeline *resource.Pipeline, trusted bool) error {
 	return nil
 }
 
-// func checkNames(pipeline *resource.Pipeline) error {
-// 	names := map[string]struct{}{}
-// 	if !pipeline.Clone.Disable {
-// 		names["clone"] = struct{}{}
-// 	}
-// 	steps := append(pipeline.Services, pipeline.Steps...)
-// 	for _, step := range steps {
-// 		_, ok := names[step.Name]
-// 		if ok {
-// 			return ErrDuplicateStepName
-// 		}
-// 		names[step.Name] = struct{}{}
-// 	}
-// 	return nil
-// }
-
 func checkSteps(pipeline *resource.Pipeline, trusted bool) error {
 	steps := append(pipeline.Services, pipeline.Steps...)
 	names := map[string]struct{}{}
@@ -83,7 +63,7 @@ func checkSteps(pipeline *resource.Pipeline, trusted bool) error {
 		// unique list of names
 		_, ok := names[step.Name]
 		if ok {
-			return ErrDuplicateStepName
+			return fmt.Errorf("linter: duplicate step names (%s)", step.Name)
 		}
 		names[step.Name] = struct{}{}
 

--- a/engine/linter/linter_test.go
+++ b/engine/linter/linter_test.go
@@ -188,15 +188,16 @@ func TestLint(t *testing.T) {
 		// 	message: "linter: duplicate step names",
 		// },
 		// {
-		// 	path:    "testdata/duplicate_step_service.yml",
-		// 	invalid: true,
-		// 	message: "linter: duplicate step names",
-		// },
-		// {
 		// 	path:    "testdata/missing_name.yml",
 		// 	invalid: true,
 		// 	message: "linter: invalid or missing name",
 		// },
+
+		{
+			path:    "testdata/duplicate_step_service.yml",
+			invalid: true,
+			message: "linter: duplicate step names (test)",
+		},
 
 		{
 			path:    "testdata/missing_dep.yml",

--- a/engine/resource/parser.go
+++ b/engine/resource/parser.go
@@ -6,6 +6,7 @@ package resource
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/drone/runner-go/manifest"
 
@@ -47,10 +48,10 @@ func lint(pipeline *Pipeline) error {
 			return errors.New("Linter: invalid or missing step name")
 		}
 		if len(step.Name) > 100 {
-			return errors.New("Linter: step name cannot exceed 100 characters")
+			return fmt.Errorf("Linter: step name (%s) cannot exceed 100 characters", step.Name)
 		}
 		if _, ok := names[step.Name]; ok {
-			return errors.New("Linter: duplicate step name")
+			return fmt.Errorf("Linter: duplicate step name (%s)", step.Name)
 		}
 		names[step.Name] = struct{}{}
 	}


### PR DESCRIPTION
It can be very difficult to debug duplicate step names and long step names in large pipelines. This PR adds additional details to the error output.