### PR TITLE
fix: [CI-15903]: Fixed secret masking issue with drone docker runner

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -427,7 +427,7 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 					//   step 2   |  MY_SEC  |  FOO
 					// If we don't add prefix in e.Env then MY_SEC env var declared in step 2 will be overriden by the secret refernce provided in step 1 and we don't want
 					// environment variable declared in step 2 to be affected thus we are making this change to retain the secret env var declared in step 2.
-					e.Env = "DRONE_PREFIX_" + e.Name
+					e.Env = "DRONE_SECRETS_" + step.Name + "_" + e.Name
 					step.Secrets = append(step.Secrets, e)
 				}
 			}

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -414,6 +414,8 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 				Env:  parts[1], //Env var
 			}
 			fmt.Println("Name of step is ", step.Name)
+
+			//We are ensuring that same secret won't be pushed twice in same step.
 			if !isPresent(step.Secrets, e) {
 				//Here we are doing this because if we create the secret with same environment variable name in other step as environment variables are getting injected in container
 				//then it may get overriden and usecase may break, so existing secret is not getting affected thus backward compatibility is ensured.

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -32,7 +32,9 @@ func toConfig(spec *Spec, step *Step) *container.Config {
 		config.Env = toEnv(step.Envs)
 	}
 	for _, sec := range step.Secrets {
-		config.Env = append(config.Env, sec.Env+"="+string(sec.Data))
+		if sec.Env != "" {
+			config.Env = append(config.Env, sec.Env+"="+string(sec.Data))
+		}
 	}
 
 	if len(step.Entrypoint) != 0 {


### PR DESCRIPTION
Here is the pipeline yaml where testing is done

```
---
kind: pipeline
type: docker
name: default

platform:
  os: linux
  arch: amd64

steps:
- name: another
  image: alpine
  commands:
  - echo "Hello world"
- name: save-to-file
  image: alpine
  environment:
    MY_SECRET:
      from_secret: check
  commands:
    - echo "$MY_SECRET" >> .secrets
    - cat .secrets
    - printenv
- name: cat
  image: alpine
  environment:
    MY_SECRET:
      from_secret: FOO
    MY_SECRET_FOO:
      from_secret: artifactory_access_token
  commands:
    - echo "$MY_SECRET" >> .secret
    - echo "$MY_SECRET_FOO" >> .secrets_2
    - cat .secrets
    - cat .secret
    - cat .secrets_2
    - printenv
- name: save-to-file-2
  image: alpine
  environment:
    MY_SECRET_1:
      from_secret: check
    MY_SECRET_FOO:
      from_secret: FOO
  commands:
    - echo "$MY_SECRET_1" >> .secrets_1
    - echo "$MY_SECRET_FOO" >> .secrets_3
    - cat .secrets_1
    - cat .secrets
    - cat .secret
    - cat .secrets_2
    - cat .secrets_3
    - printenv   
- name: save-to-file-3
  image: alpine
  commands:
    - cat .secrets_1
    - cat .secrets
    - cat .secret
    - cat .secrets_2
    - cat .secrets_3
    - printenv    
```

Video:

https://github.com/user-attachments/assets/9bae121d-265d-4cbd-9e2d-7cd93b1cb74a

